### PR TITLE
Desktop balance

### DIFF
--- a/account.api/pom.xml
+++ b/account.api/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>accountapi</artifactId> <!-- NB this is part of the war file name -->
-  <version>0.4.1-RELEASE</version>
+  <version>0.4.2-SNAPSHOT</version>
   
   <packaging>war</packaging>
   <name>Account API</name>

--- a/account.api/src/main/java/com/felixalacampagne/account/common/Utils.java
+++ b/account.api/src/main/java/com/felixalacampagne/account/common/Utils.java
@@ -1,0 +1,76 @@
+package com.felixalacampagne.account.common;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import com.felixalacampagne.account.persistence.entities.Transaction;
+
+public class Utils
+{
+
+   // yyyy-MM-dd is the iso date format supported by Javascript Date
+   public static final DateTimeFormatter DATEFORMAT_YYYYMMDD = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+   public static BigDecimal getZeroOrValue(BigDecimal value)
+   {
+      return value==null ? BigDecimal.ZERO : value;
+   }
+
+   // Combines credit and debit into a single amount, +ve for credit, -ve for debit
+   public static BigDecimal getAmount(Transaction txn)
+   {
+      return getZeroOrValue(txn.getCredit()).subtract(getZeroOrValue(txn.getDebit()));
+   }
+
+   // Like equals but true if both are null
+   public static boolean areSame(BigDecimal one, BigDecimal two)
+   {
+      if((one == null) && (two == null))
+         return true;
+      else if(((one == null) && (two != null))
+             || ((one != null) && (two == null)))
+         return false;
+      return one.compareTo(two) == 0;
+   }
+
+
+   public static String getToken(Transaction transaction)
+   {
+      // Crude value intended to confirm the record being updated is the correct one,
+      // eg. to avoid a wrong/spoofed ID from being sent from the client
+      return formatDate(transaction.getDate())
+         + ":" + formatAmount(transaction.getDebit())
+         + ":" + formatAmount(transaction.getDebit())
+         + ":" + transaction.getType()
+         + ":" + transaction.getComment()
+         + ":" + transaction.getChecked();
+   }
+
+   public static String formatAmount(BigDecimal bigdec)
+   {
+   String amt = "";
+      if(bigdec != null)
+      {
+         amt = bigdec.setScale(2, RoundingMode.HALF_UP).toString();
+      }
+      return amt;
+   }
+
+   public static String formatDate(LocalDate ts)
+   {
+      String date = "";
+      if(ts != null)
+      {
+         date = ts.format(DATEFORMAT_YYYYMMDD);
+      }
+      return date;
+   }
+
+
+   private Utils()
+   {
+      // utility class should only contain statics
+   }
+}

--- a/account.api/src/main/java/com/felixalacampagne/account/model/TransactionItem.java
+++ b/account.api/src/main/java/com/felixalacampagne/account/model/TransactionItem.java
@@ -9,10 +9,11 @@ public class TransactionItem
    private final String type;
    private final long id;
    private final boolean locked;
+   private final String balance;
    private final String token;
 
    public TransactionItem(Long accid, String date, String amount, String type, String comment,
-                          boolean locked, long id, String token)
+                          boolean locked, long id, String token, String balance)
    {
       this.accid = accid;
       this.date = date;
@@ -21,6 +22,7 @@ public class TransactionItem
       this.comment = comment;
       this.id = id;
       this.locked = locked;
+		this.balance = balance;
       this.token = token; // Maybe create this here?
    }
 
@@ -33,6 +35,11 @@ public class TransactionItem
    public String getAmount()
    {
       return amount;
+   }
+
+   public String getBalance()
+   {
+      return balance;
    }
 
    public long getAccid()
@@ -63,6 +70,7 @@ public class TransactionItem
             + ", type=" + type
             + ", id=" + id
             + ", locked=" + locked
+            + ", balance=" + balance
             + ", token=" + token
             + "]";
    }

--- a/account.api/src/main/java/com/felixalacampagne/account/persistence/repository/TransactionJpaRepository.java
+++ b/account.api/src/main/java/com/felixalacampagne/account/persistence/repository/TransactionJpaRepository.java
@@ -44,5 +44,9 @@ public interface TransactionJpaRepository extends JpaRepository<Transaction, Lon
    List<Transaction> findByAccountId(long accountId, Pageable pageable);
    long countByAccountId(long accountId);
 
-   Optional<Transaction> findFirstByAccountIdOrderBySequenceDesc(long accountId);
+   Optional<Transaction> findFirstByAccountIdOrderBySequenceDesc(long accountId); // latest
+
+   Optional<Transaction> findFirstByAccountIdAndSequenceLessThanOrderBySequenceDesc(long accountId, long sequence); // previous
+
+   List<Transaction> findByAccountIdAndSequenceGreaterThanOrderBySequenceAsc(long accountId, long sequence); // following
 }

--- a/account.api/src/main/java/com/felixalacampagne/account/service/BalanceService.java
+++ b/account.api/src/main/java/com/felixalacampagne/account/service/BalanceService.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.felixalacampagne.account.common.Utils;
 import com.felixalacampagne.account.persistence.entities.Transaction;
 import com.felixalacampagne.account.persistence.repository.TransactionJpaRepository;
 

--- a/account.api/src/main/java/com/felixalacampagne/account/service/BalanceService.java
+++ b/account.api/src/main/java/com/felixalacampagne/account/service/BalanceService.java
@@ -1,0 +1,84 @@
+package com.felixalacampagne.account.service;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.felixalacampagne.account.persistence.entities.Transaction;
+import com.felixalacampagne.account.persistence.repository.TransactionJpaRepository;
+
+@Service
+public class BalanceService
+{
+   private final Logger log = LoggerFactory.getLogger(this.getClass());
+   private final TransactionJpaRepository transactionJpaRepository;
+
+   public BalanceService(TransactionJpaRepository transactionJpaRepository) {
+      this.transactionJpaRepository = transactionJpaRepository;
+   }
+
+   @Transactional
+   public Transaction calculateBalances(Transaction startTransaction)
+   {
+      log.info("calculateBalances: startTransaction:{}", startTransaction.getSequence());
+      BigDecimal balance = BigDecimal.ZERO;
+      BigDecimal amt = Utils.getAmount(startTransaction);
+
+      // Get last transaction
+      Optional<Transaction> prevtxn = getPreviousTransaction(startTransaction);
+      if(prevtxn.isPresent())
+      {
+         balance = Utils.getZeroOrValue(prevtxn.get().getBalance());
+      }
+      balance = balance.add(amt);
+
+      // Could check if new balance is same as old balance and stop if no change
+      startTransaction.setBalance(balance);
+      startTransaction = transactionJpaRepository.save(startTransaction);
+
+      // Now need to update the balance for any transactions which occurred AFTER the updated transaction
+      List<Transaction> txns = getFollowingTransactions(startTransaction);
+
+      for(Transaction nxttxn : txns)
+      {
+         amt = Utils.getAmount(nxttxn);
+         balance = balance.add(amt);
+         nxttxn.setBalance(balance);
+      }
+      transactionJpaRepository.saveAll(txns);
+      transactionJpaRepository.flush();
+      log.info("calculateBalances: done startTransaction:{}", startTransaction.getSequence());
+      return startTransaction;
+   }
+
+   // These were originally intended to go in TransactionService but that causes a
+   // circular dependency between TransactionService and BalanceService.
+   // BalanceService is only needed to make sure that Spring recognises the @Transactionals
+   // since there is some issue when calling a @Transactional method from a method in the
+   // same class.
+   // Couldn't immediately think of an alternative way to do it and these methods are only really needed for
+   // balance calculations.
+   // Workaround could be to inject BalanceService into TransactionService and use @PostConstruct init method
+   // to set TransactionService in BalanceService. There are other options using @Lazy.
+   public Optional<Transaction> getLatestTransaction(long accountId)
+   {
+      return transactionJpaRepository.findFirstByAccountIdOrderBySequenceDesc(accountId);
+   }
+
+   public Optional<Transaction> getPreviousTransaction(Transaction txn)
+   {
+      return transactionJpaRepository.findFirstByAccountIdAndSequenceLessThanOrderBySequenceDesc(txn.getAccountId(), txn.getSequence());
+   }
+
+   public List<Transaction> getFollowingTransactions(Transaction txn)
+   {
+      return transactionJpaRepository.findByAccountIdAndSequenceGreaterThanOrderBySequenceAsc(txn.getAccountId(), txn.getSequence());
+   }
+
+
+}

--- a/account.api/src/main/java/com/felixalacampagne/account/service/TransactionService.java
+++ b/account.api/src/main/java/com/felixalacampagne/account/service/TransactionService.java
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.felixalacampagne.account.common.Utils;
 import com.felixalacampagne.account.model.TransactionItem;
 import com.felixalacampagne.account.model.Transactions;
 import com.felixalacampagne.account.persistence.entities.Transaction;

--- a/account.api/src/main/java/com/felixalacampagne/account/service/TransactionService.java
+++ b/account.api/src/main/java/com/felixalacampagne/account/service/TransactionService.java
@@ -82,6 +82,8 @@ public class TransactionService
       Transaction txn = mapToEntity(transactionItem);
 
       connectionResurrector.ressurectConnection();
+
+      // TODO: calculate the balance field
       txn = transactionJpaRepository.saveAndFlush(txn);
       log.info("addTransaction: added transaction for account id {}: id:{}", txn.getAccountId(), txn.getSequence());
    }
@@ -137,6 +139,7 @@ public class TransactionService
       txn.setComment(updtxn.getComment());
       if(!(areEqual(txn.getCredit(), updtxn.getCredit()) && areEqual(txn.getDebit(), updtxn.getDebit())))
       {
+         // TODO: re-calculate the balance fields for this a subsequent txns. Will need a DB transaction.
          txn.setBalance(null);
       }
       txn.setCredit(updtxn.getCredit());
@@ -220,7 +223,7 @@ public class TransactionService
             formatAmount(amount),
             t.getType(),
             t.getComment(),
-            t.getChecked(), t.getSequence(), token);
+            t.getChecked(), t.getSequence(), token, formatAmount(t.getBalance()));
    }
 
    private String formatAmount(BigDecimal bigdec)

--- a/account.api/src/main/java/com/felixalacampagne/account/standingorder/StandingOrderExecutor.java
+++ b/account.api/src/main/java/com/felixalacampagne/account/standingorder/StandingOrderExecutor.java
@@ -3,6 +3,7 @@ package com.felixalacampagne.account.standingorder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -30,10 +31,13 @@ public class StandingOrderExecutor
    //   day of week
    // "0 10 08 * * ?"  08:10 every day
    // "*/10 * * * * *" every 10 seconds
+
+   @Value("${falc.account.standingorder.cron}")
+   private String cronstr;
    @Scheduled(cron = "${falc.account.standingorder.cron}")
    public void standingOrderDailyTask()
    {
-      log.info("standingOrderDailyTask: processing standing orders: start");
+      log.info("standingOrderDailyTask: processing standing orders: cronstr:{}", cronstr);
       standingOrderProcessor.processStandingOrders();
       log.info("standingOrderDailyTask: processing standing orders: finished");
    }

--- a/account.api/src/main/java/com/felixalacampagne/account/standingorder/StandingOrderProcessingService.java
+++ b/account.api/src/main/java/com/felixalacampagne/account/standingorder/StandingOrderProcessingService.java
@@ -10,6 +10,7 @@ import com.felixalacampagne.account.persistence.entities.StandingOrders;
 import com.felixalacampagne.account.persistence.entities.Transaction;
 import com.felixalacampagne.account.persistence.repository.StandingOrdersJpaRepository;
 import com.felixalacampagne.account.persistence.repository.TransactionJpaRepository;
+import com.felixalacampagne.account.service.TransactionService;
 
 @Service
 public class StandingOrderProcessingService
@@ -17,21 +18,21 @@ public class StandingOrderProcessingService
    Logger log = LoggerFactory.getLogger(this.getClass());
 
    private final StandingOrdersJpaRepository standingOrdersJpaRepository;
-   private final TransactionJpaRepository transactionJpaRepository;
+   private final TransactionService transactionService;
 
    @Autowired
    public StandingOrderProcessingService(StandingOrdersJpaRepository standingOrdersJpaRepository,
-                                         TransactionJpaRepository transactionJpaRepository)
+   		TransactionService transactionService)
    {
       this.standingOrdersJpaRepository = standingOrdersJpaRepository;
-      this.transactionJpaRepository = transactionJpaRepository;
+      this.transactionService = transactionService;
    }
 
    @Transactional
    void updateTxnAndSo(StandingOrders so, Transaction txn)
    {
-      // needs to be in same transaction
-      this.transactionJpaRepository.saveAndFlush(txn);
+      // must add transaction via the transactionservice in order to calculate the balance 
+      this.transactionService.add(txn);
       this.standingOrdersJpaRepository.saveAndFlush(so);
    }
 }

--- a/account.api/src/main/java/com/felixalacampagne/account/standingorder/StandingOrderProcessor.java
+++ b/account.api/src/main/java/com/felixalacampagne/account/standingorder/StandingOrderProcessor.java
@@ -70,7 +70,7 @@ public class StandingOrderProcessor
 
    public void processStandingOrder(StandingOrders so)
    {
-      BigDecimal balance = BigDecimal.ZERO;
+      
       log.info("processStandingOrder: processing {}", so);
 
       // Generate comment
@@ -82,16 +82,7 @@ public class StandingOrderProcessor
       BigDecimal soamt = so.getSOAmount();
       Long accId = so.getAccount().getAccId();
       
-      // Get last transaction
-      Optional<Transaction> lasttxn = this.transactionService.getLatestTransaction(accId);
 
-      // Calculate next balance
-      if(lasttxn.isPresent() && (lasttxn.get().getBalance() != null))
-      {
-         balance = lasttxn.get().getBalance();
-      }
-      balance = balance.subtract(soamt);
-      
       
       // create new transaction
       Transaction sotxn = new Transaction();
@@ -108,8 +99,6 @@ public class StandingOrderProcessor
       {
          sotxn.setDebit(soamt);
       }
-      sotxn.setBalance(balance);
-
       adjustSODates(so);
 
       // needs to be in same transaction and there is potentially an issue

--- a/account.api/src/main/resources/application-dev.properties
+++ b/account.api/src/main/resources/application-dev.properties
@@ -1,7 +1,7 @@
 falc.account.name=DevJAccount
 falc.account.db=TEST
-falc.account.version=0.2.1
-falc.account.standingorder.cron=*/60 * * * * *
+falc.account.version=0.4.2adev
+falc.account.standingorder.cron=* */2 * * * *
 spring.datasource.url=jdbc:ucanaccess://E:/Development/workspace/accountREST/acc2003_TEST.mdb
 
 

--- a/account.api/src/main/resources/application.properties
+++ b/account.api/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 falc.account.name=JAccount
 falc.account.db=LIVE
-falc.account.version=0.4.1
+falc.account.version=0.4.2a
 #falc.account.standingorder.cron=0 10 08 * * ?
 falc.account.standingorder.cron=* 5 * * * *
 

--- a/account.api/src/main/resources/application.properties
+++ b/account.api/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 falc.account.name=JAccount
 falc.account.db=LIVE
-falc.account.version=0.4.2b
+falc.account.version=0.4.2c
 #falc.account.standingorder.cron=0 10 08 * * ?
-falc.account.standingorder.cron=0 5 */1 * * ?
+falc.account.standingorder.cron=0 5 */4 * * ?
 
 spring.application.name=accountapi
 

--- a/account.api/src/main/resources/application.properties
+++ b/account.api/src/main/resources/application.properties
@@ -1,8 +1,8 @@
 falc.account.name=JAccount
 falc.account.db=LIVE
-falc.account.version=0.4.2a
+falc.account.version=0.4.2b
 #falc.account.standingorder.cron=0 10 08 * * ?
-falc.account.standingorder.cron=* 5 * * * *
+falc.account.standingorder.cron=0 5 */1 * * ?
 
 spring.application.name=accountapi
 

--- a/account.api/src/test/java/com/felixalacampagne/account/persistence/repository/TransactionJpaRepositoryTest.java
+++ b/account.api/src/test/java/com/felixalacampagne/account/persistence/repository/TransactionJpaRepositoryTest.java
@@ -3,9 +3,7 @@ package com.felixalacampagne.account.persistence.repository;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigDecimal;
-import java.sql.Timestamp;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -57,6 +55,30 @@ class TransactionJpaRepositoryTest
    {
       Optional<Transaction> latesttxn = transactionJpaRepository.findFirstByAccountIdOrderBySequenceDesc(1L);
       log.info("testFindLatest: found {} for account 1", latesttxn.get());
+   }
+
+   @Test
+   void testFindPrevious()
+   {
+      List<Transaction> txnsforacc = transactionJpaRepository.findByAccountId(1L, PageRequest.of(0, 25, Sort.by("sequence").descending()));
+
+      Transaction txn = txnsforacc.get(5);
+
+      Optional<Transaction> prevtxn = transactionJpaRepository.findFirstByAccountIdAndSequenceLessThanOrderBySequenceDesc(txn.getAccountId(), txn.getSequence());
+      log.info("testFindLatest: found {} for account 1", prevtxn.get());
+      assertEquals(txnsforacc.get(6), prevtxn.get());
+   }
+
+   @Test
+   void testFindFollowing()
+   {
+      List<Transaction> txnsforacc = transactionJpaRepository.findByAccountId(1L, PageRequest.of(0, 25, Sort.by("sequence").descending()));
+
+      Transaction txn = txnsforacc.get(6); // the seventh from last
+
+      List<Transaction> txns = transactionJpaRepository.findByAccountIdAndSequenceGreaterThanOrderBySequenceAsc(txn.getAccountId(), txn.getSequence());
+      log.info("testFindLatest: found {} following txns", txns.size());
+      assertEquals(6, txns.size());
    }
 
 

--- a/account.api/src/test/java/com/felixalacampagne/account/service/TransactionServiceTest.java
+++ b/account.api/src/test/java/com/felixalacampagne/account/service/TransactionServiceTest.java
@@ -49,7 +49,7 @@ class TransactionServiceTest
       TransactionItem updtxnitm = new TransactionItem(
             origtxnitm.getAccid(), origtxnitm.getDate(), origtxnitm.getAmount(), origtxnitm.getType(),
             "TEST" + origtxnitm.getComment(),
-            origtxnitm.isLocked(), origtxnitm.getId(), origtxnitm.getToken());
+            origtxnitm.isLocked(), origtxnitm.getId(), origtxnitm.getToken(), origtxnitm.getBalance());
 
       transactionService.updateTransaction(updtxnitm);
 
@@ -63,7 +63,7 @@ class TransactionServiceTest
             origtxnitm.getAccid(), origtxnitm.getDate(), origtxnitm.getAmount(), origtxnitm.getType(),
             origtxnitm.getComment(),
             origtxnitm.isLocked(), origtxnitm.getId(),
-            updtxnitm.getToken()); // this transaction now has the token of the update
+            updtxnitm.getToken(), null); // this transaction now has the token of the update
       transactionService.updateTransaction(origtxnitm);
    }
 }

--- a/account.api/src/test/java/com/felixalacampagne/account/service/TransactionServiceTest.java
+++ b/account.api/src/test/java/com/felixalacampagne/account/service/TransactionServiceTest.java
@@ -1,11 +1,14 @@
 package com.felixalacampagne.account.service;
 
+import java.util.List;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
 import com.felixalacampagne.account.AccountTest;
 import com.felixalacampagne.account.model.TransactionItem;
@@ -39,20 +42,18 @@ class TransactionServiceTest
    @Test
    void testUpdateTransaction()
    {
-      Transaction transaction = transactionJpaRepository.findByAccountId(1L, Pageable.unpaged())
-                .stream().filter((t) -> !t.getChecked())
-                         .findAny()
-                         .get();
+      List<Transaction> txnsforacc = transactionJpaRepository.findByAccountId(22L, PageRequest.of(0, 25, Sort.by("sequence").descending()));
 
-      Transaction origtxn = transactionService.getTransaction(transaction.getSequence()).get();
+      Transaction origtxn = txnsforacc.get(5);
       TransactionItem origtxnitm = transactionService.mapToItem(origtxn);
       TransactionItem updtxnitm = new TransactionItem(
-            origtxnitm.getAccid(), origtxnitm.getDate(), origtxnitm.getAmount(), origtxnitm.getType(),
+            origtxnitm.getAccid(), origtxnitm.getDate(), "9" + origtxnitm.getAmount(), origtxnitm.getType(),
             "TEST" + origtxnitm.getComment(),
             origtxnitm.isLocked(), origtxnitm.getId(), origtxnitm.getToken(), origtxnitm.getBalance());
 
-      transactionService.updateTransaction(updtxnitm);
-
+      Transaction updtxn = transactionService.updateTransaction(updtxnitm);
+      log.info("testUpdateTransaction: new amount:{} balance: before:{} after:{}",
+            updtxnitm.getAmount(), origtxn.getBalance(), updtxnitm.getBalance());
 
       Transaction updatedtxn = transactionService.getTransaction(origtxnitm.getId()).get();
       updtxnitm = transactionService.mapToItem(updatedtxn);
@@ -64,6 +65,6 @@ class TransactionServiceTest
             origtxnitm.getComment(),
             origtxnitm.isLocked(), origtxnitm.getId(),
             updtxnitm.getToken(), null); // this transaction now has the token of the update
-      transactionService.updateTransaction(origtxnitm);
+      updtxn = transactionService.updateTransaction(origtxnitm);
    }
 }

--- a/account.api/src/test/resources/.gitignore
+++ b/account.api/src/test/resources/.gitignore
@@ -1,1 +1,2 @@
 /application-test.properties
+/application-dev.properties

--- a/account.api/src/test/resources/application-dev.properties.template
+++ b/account.api/src/test/resources/application-dev.properties.template
@@ -1,0 +1,9 @@
+falc.account.name=DevJAccount
+falc.account.db=TEST
+falc.account.version=0.4.2adev
+falc.account.standingorder.cron=* 0 */2 * * ?
+spring.datasource.url=jdbc:ucanaccess://E:/Development/workspace/accountREST/acc2003_TEST.mdb
+# C:/Development/accountDB/acc2003TEST.mdb
+
+# this causes an exception when debugging so set it to a high value
+spring.datasource.hikari.leakDetectionThreshold=1000000

--- a/account.ui/src/app/app.component.css
+++ b/account.ui/src/app/app.component.css
@@ -87,6 +87,7 @@
 td.account-amount, th.account-amount
 {
 	text-align: right;
+	border-bottom-width: 0;
 }
 
 /*
@@ -111,14 +112,17 @@ td.account-amount, th.account-amount
    to add a custom file to bootstrap directory - which seems like a terrible idea.
    So this will have to do for now as it appears to do what I want, ie. put the rows closer together.
  */
-td {
+td, tr {
   padding-top: 0 !important;
   margin-top: 0 !important;
   padding-bottom: 0 !important;
   margin-bottom: 0 !important;
-  font-size: 12pt !important;
-  line-height: 16px;
+  font-size: 10pt !important;
+
+  border-bottom-width: 0 !important;
 }
 
-
+td.nowrap  {
+	white-space: nowrap;
+}
 

--- a/account.ui/src/app/app.component.css
+++ b/account.ui/src/app/app.component.css
@@ -76,3 +76,49 @@
  table.table.table-striped tr.txn-locked td {
   background-color:#f3eefd;
 }
+
+
+/* Couldn't figure out if there was a nicer way to apply the right to td and th with the account-amount class.
+   .account-amount td,th   - didn't work
+   td,th account-amount    - didn't work
+   account-amount          - this worked but applied to everything
+   td.account-amount, th.account-amount - works but is very ugly
+ */
+td.account-amount, th.account-amount
+{
+	text-align: right;
+}
+
+/*
+   Text colour does not change when '!important' is omitted
+ */
+.account-negbalance
+{
+	color: red !important;
+}
+
+
+/* Trying to reduce the wasted space between the rows. Some was due to padding on the update button and icon
+   but most is due to the bootstrap table css and nowhere is it documented how to remove the padding.
+   The only thing that has made any difference is the padding/margin settings, and they only work if
+   !important is used. Why on earth don't they realise that not everyone wants to waste very valuable screen
+   space by filling it with useless whitespace??
+   
+   The 'btn' class is modified in the .scss file to remove the excessive line-height, padding and margin.
+   I couldn't figure out how to do the same for the 'table' class which is using. The bootstrap docs
+   refer to variables being used to set properties but I failed to find anything which made an sense
+   regarding how to override the variable - it seems the only way to do it is to modify the original values or
+   to add a custom file to bootstrap directory - which seems like a terrible idea.
+   So this will have to do for now as it appears to do what I want, ie. put the rows closer together.
+ */
+td {
+  padding-top: 0 !important;
+  margin-top: 0 !important;
+  padding-bottom: 0 !important;
+  margin-bottom: 0 !important;
+  font-size: 12pt !important;
+  line-height: 16px;
+}
+
+
+

--- a/account.ui/src/app/app.component.html
+++ b/account.ui/src/app/app.component.html
@@ -21,13 +21,14 @@
   <table class="table table-striped table-sm">
     <thead class="thead-inverse">
     <tr><th colspan="3">Transactions for {{activeaccount.name}}</th></tr>
-    <tr><th>Date</th><th>Memo</th><th>Amount</th></tr>
+    <tr><th>Date</th><th>Memo</th><th>Amount</th><th *ngIf="desktopDisplay">Balance</th><th *ngIf="desktopDisplay"></th></tr>
     </thead>
     <tbody class="">
     <tr *ngFor="let txn of transactions" [ngClass]="{'table-success': txn.locked}">
        <td>{{txn.date}}</td>
        <td (swipeleft)="!txn.locked && open(content, txn)">{{txn.comment}}</td>
        <td>{{txn.amount}}</td>
+       <td *ngIf="desktopDisplay">{{txn.balance}}</td>
        <td *ngIf="desktopDisplay">
        <button *ngIf="!txn.locked" class="btn" (click)="open(content, txn)"><i class="bi bi-pencil-square" aria-hidden="true"></i></button>
        </td>

--- a/account.ui/src/app/app.component.html
+++ b/account.ui/src/app/app.component.html
@@ -21,16 +21,16 @@
   <table class="table table-striped table-sm">
     <thead class="thead-inverse">
     <tr><th colspan="3">Transactions for {{activeaccount.name}}</th></tr>
-    <tr><th>Date</th><th>Memo</th><th>Amount</th><th *ngIf="desktopDisplay">Balance</th><th *ngIf="desktopDisplay"></th></tr>
+    <tr><th>Date</th><th>Memo</th><th class="account-amount">Amount</th><th class="account-amount" *ngIf="desktopDisplay">Balance</th><th *ngIf="desktopDisplay"></th></tr>
     </thead>
-    <tbody class="">
+    <tbody >
     <tr *ngFor="let txn of transactions" [ngClass]="{'table-success': txn.locked}">
        <td>{{txn.date}}</td>
        <td (swipeleft)="!txn.locked && open(content, txn)">{{txn.comment}}</td>
-       <td>{{txn.amount}}</td>
-       <td *ngIf="desktopDisplay">{{txn.balance}}</td>
+       <td class="account-amount">{{txn.amount}}</td>
+       <td class="account-amount" [ngClass]="{'account-negbalance': txn.balance.startsWith('-')}" *ngIf="desktopDisplay">{{txn.balance}}</td>
        <td *ngIf="desktopDisplay">
-       <button *ngIf="!txn.locked" class="btn" (click)="open(content, txn)"><i class="bi bi-pencil-square" aria-hidden="true"></i></button>
+       <button *ngIf="!txn.locked" class="acc-table-btn" (click)="open(content, txn)"><i class="bi bi-pencil-square" aria-hidden="true"></i></button>
        </td>
        </tr>
     </tbody>

--- a/account.ui/src/app/app.component.html
+++ b/account.ui/src/app/app.component.html
@@ -25,7 +25,7 @@
     </thead>
     <tbody >
     <tr *ngFor="let txn of transactions" [ngClass]="{'table-success': txn.locked}">
-       <td>{{txn.date}}</td>
+       <td class="nowrap">{{txn.date.substring(2)}}</td>
        <td (swipeleft)="!txn.locked && open(content, txn)">{{txn.comment}}</td>
        <td class="account-amount">{{txn.amount}}</td>
        <td class="account-amount" [ngClass]="{'account-negbalance': txn.balance.startsWith('-')}" *ngIf="desktopDisplay">{{txn.balance}}</td>

--- a/account.ui/src/assets/accountapi/listaccount
+++ b/account.ui/src/assets/accountapi/listaccount
@@ -3,6 +3,10 @@
         {
             "id": 1,
             "name": "Chris Test Bank"
-        }
+        },
+        {
+            "id": 22,
+            "name": "Chris Alternate Test Bank"
+        }        
     ]
 }

--- a/account.ui/src/assets/accountapi/listtransaction/1
+++ b/account.ui/src/assets/accountapi/listtransaction/1
@@ -2,182 +2,278 @@
     "transactions": [
         {
             "accid": 1,
-            "comment": "Transfer TO KeyTrade Current KEYT201802",
-            "date": "2018-02-15",
-            "amount": "300.00",
-            "type": "TFR",
-            "locked": true
+            "comment": "Grocery - GB, Tervuren",
+            "date": "1998-10-06",
+            "amount": "4472.00",
+            "type": "BC",
+            "id": 1308,
+            "locked": true,
+            "balance": "147500.00",
+            "token": "1998-10-06:4472.00:4472.00:BC:Grocery - GB, Tervuren:true"
         },
         {
             "accid": 1,
-            "comment": "Linda-Grocery  week 8 On:18 Feb 18",
-            "date": "2018-02-19",
-            "amount": "150.00",
-            "type": "GROC",
-            "locked": true            
-        },
-        {
-            "accid": 1,
-            "comment": "BCC MC 2018 02 (847233244948) BCC MC (EUR) (BE72 0012 1222 0316)  On:18 Feb 19:21",
-            "date": "2018-02-28",
-            "amount": "970.96",
+            "comment": "05/10/98 Visa BCC(Tfr) On:17 Oct 11:25",
+            "date": "1998-10-17",
+            "amount": "34806.00",
             "type": "PTFR",
-            "locked": true
+            "id": 1310,
+            "locked": true,
+            "balance": "112694.00",
+            "token": "1998-10-17:34806.00:34806.00:PTFR:05/10/98 Visa BCC(Tfr) On:17 Oct 11:25:true"
         },
         {
             "accid": 1,
-            "comment": "Adele resto",
-            "date": "2018-02-13",
-            "amount": "2.42",
-            "type": "BC"
+            "comment": "Grocery - Delhaize, Perwez",
+            "date": "1998-10-13",
+            "amount": "1181.00",
+            "type": "BC",
+            "id": 1311,
+            "locked": true,
+            "balance": "111513.00",
+            "token": "1998-10-13:1181.00:1181.00:BC:Grocery - Delhaize, Perwez:true"
         },
         {
             "accid": 1,
-            "comment": "Adele resto",
-            "date": "2018-02-14",
-            "amount": "2.38",
-            "type": "BC"
+            "comment": "Escort2, Perwez (70434km 28.68l *)",
+            "date": "1998-10-13",
+            "amount": "1000.00",
+            "type": "BC",
+            "id": 1312,
+            "locked": true,
+            "balance": "110513.00",
+            "token": "1998-10-13:1000.00:1000.00:BC:Escort2, Perwez (70434km 28.68l *):true"
         },
         {
             "accid": 1,
-            "comment": "Lindap Cat litter (FVAS 40 20.02.2018) Animal Success,Rue de Huy 73c,4280,Hannut (BE75 3400 8524 4951) ",
-            "date": "2018-02-21",
-            "amount": "312.18",
-            "type": "PNOW"
+            "comment": "Pharm.Mouton - 2xOtrivine + 5Bancontact charge",
+            "date": "1998-10-15",
+            "amount": "349.00",
+            "type": "BC",
+            "id": 1313,
+            "locked": true,
+            "balance": "110164.00",
+            "token": "1998-10-15:349.00:349.00:BC:Pharm.Mouton - 2xOtrivine + 5Bancontact charge:true"
         },
         {
             "accid": 1,
-            "comment": "Lindap Washing cat beds (17466/1251) Nouveau Lavoir Hannutois,Ch.de Wavre 11,3280,Hannut (BE86 2400 2595 2150) ",
-            "date": "2018-02-21",
-            "amount": "205.70",
+            "comment": "Securex (Dental Feb 98)",
+            "date": "1998-10-01",
+            "amount": "-618.00",
+            "type": "MED",
+            "id": 1314,
+            "locked": true,
+            "balance": "110782.00",
+            "token": "1998-10-01:::MED:Securex (Dental Feb 98):true"
+        },
+        {
+            "accid": 1,
+            "comment": "Securex (Dental Aug L+C)",
+            "date": "1998-11-01",
+            "amount": "-618.00",
+            "type": "MED",
+            "id": 1315,
+            "locked": true,
+            "balance": "111400.00",
+            "token": "1998-11-01:::MED:Securex (Dental Aug L+C):true"
+        },
+        {
+            "accid": 1,
+            "comment": "Nov 98 Escort 96 On:21 Oct 98",
+            "date": "1998-11-01",
+            "amount": "7794.00",
+            "type": "CAR",
+            "id": 1318,
+            "locked": true,
+            "balance": "103606.00",
+            "token": "1998-11-01:7794.00:7794.00:CAR:Nov 98 Escort 96 On:21 Oct 98:true"
+        },
+        {
+            "accid": 1,
+            "comment": "Escort2, Nossegem (69936km 35.15l)",
+            "date": "1998-10-08",
+            "amount": "1096.00",
+            "type": "BC",
+            "id": 1319,
+            "locked": true,
+            "balance": "102510.00",
+            "token": "1998-10-08:1096.00:1096.00:BC:Escort2, Nossegem (69936km 35.15l):true"
+        },
+        {
+            "accid": 1,
+            "comment": "Escort2, Orbais (70902km 41.31l)",
+            "date": "1998-10-20",
+            "amount": "1400.00",
+            "type": "BC",
+            "id": 1320,
+            "locked": true,
+            "balance": "101110.00",
+            "token": "1998-10-20:1400.00:1400.00:BC:Escort2, Orbais (70902km 41.31l):true"
+        },
+        {
+            "accid": 1,
+            "comment": "Grocery - Delhaize, Perwez",
+            "date": "1998-10-20",
+            "amount": "2505.00",
+            "type": "BC",
+            "id": 1321,
+            "locked": true,
+            "balance": "98605.00",
+            "token": "1998-10-20:2505.00:2505.00:BC:Grocery - Delhaize, Perwez:true"
+        },
+        {
+            "accid": 1,
+            "comment": "Escort2, Orbais (71327km 29.50l)",
+            "date": "1998-10-26",
+            "amount": "1000.00",
+            "type": "BC",
+            "id": 1324,
+            "locked": true,
+            "balance": "97605.00",
+            "token": "1998-10-26:1000.00:1000.00:BC:Escort2, Orbais (71327km 29.50l):true"
+        },
+        {
+            "accid": 1,
+            "comment": "Transfer FROM Kreditbank Savings",
+            "date": "1998-10-26",
+            "amount": "-40000.00",
+            "type": "PTFR",
+            "id": 1325,
+            "locked": true,
+            "balance": "137605.00",
+            "token": "1998-10-26:::PTFR:Transfer FROM Kreditbank Savings:true"
+        },
+        {
+            "accid": 1,
+            "comment": "Manual transfer on 26/10/98 to CERA savings",
+            "date": "1998-10-27",
+            "amount": "40000.00",
+            "type": "PFUT",
+            "id": 1327,
+            "locked": true,
+            "balance": "97605.00",
+            "token": "1998-10-27:40000.00:40000.00:PFUT:Manual transfer on 26/10/98 to CERA savings:true"
+        },
+        {
+            "accid": 1,
+            "comment": "KB, Tervuren",
+            "date": "1998-10-27",
+            "amount": "10000.00",
+            "type": "ATM",
+            "id": 1329,
+            "locked": true,
+            "balance": "87605.00",
+            "token": "1998-10-27:10000.00:10000.00:ATM:KB, Tervuren:true"
+        },
+        {
+            "accid": 1,
+            "comment": "Grocery - GB, Tervuren",
+            "date": "1998-10-27",
+            "amount": "4213.00",
+            "type": "BC",
+            "id": 1331,
+            "locked": true,
+            "balance": "83392.00",
+            "token": "1998-10-27:4213.00:4213.00:BC:Grocery - GB, Tervuren:true"
+        },
+        {
+            "accid": 1,
+            "comment": "Escort2, Orbais (71848km 35.4l)",
+            "date": "1998-10-30",
+            "amount": "1200.00",
+            "type": "BC",
+            "id": 1332,
+            "locked": true,
+            "balance": "82192.00",
+            "token": "1998-10-30:1200.00:1200.00:BC:Escort2, Orbais (71848km 35.4l):true"
+        },
+        {
+            "accid": 1,
+            "comment": "Nov 98 On:08 Nov 98",
+            "date": "1998-11-18",
+            "amount": "25000.00",
+            "type": "MORT",
+            "id": 1336,
+            "locked": true,
+            "balance": "57192.00",
+            "token": "1998-11-18:25000.00:25000.00:MORT:Nov 98 On:08 Nov 98:true"
+        },
+        {
+            "accid": 1,
+            "comment": "Grocery - GB, Tervuren",
+            "date": "1998-11-03",
+            "amount": "2794.00",
+            "type": "BC",
+            "id": 1337,
+            "locked": true,
+            "balance": "54398.00",
+            "token": "1998-11-03:2794.00:2794.00:BC:Grocery - GB, Tervuren:true"
+        },
+        {
+            "accid": 1,
+            "comment": "Escort2, Orbais (72345km 38.36l)",
+            "date": "1998-11-06",
+            "amount": "1300.00",
+            "type": "BC",
+            "id": 1338,
+            "locked": true,
+            "balance": "53098.00",
+            "token": "1998-11-06:1300.00:1300.00:BC:Escort2, Orbais (72345km 38.36l):true"
+        },
+        {
+            "accid": 1,
+            "comment": "Escort2, Orbais (72773km 25.50l *)",
+            "date": "1998-11-13",
+            "amount": "1000.00",
+            "type": "BC",
+            "id": 1340,
+            "locked": true,
+            "balance": "52098.00",
+            "token": "1998-11-13:1000.00:1000.00:BC:Escort2, Orbais (72773km 25.50l *):true"
+        },
+        {
+            "accid": 1,
+            "comment": "Grocery - GB, Tervuren",
+            "date": "1998-11-17",
+            "amount": "4515.00",
+            "type": "BC",
+            "id": 1341,
+            "locked": true,
+            "balance": "47583.00",
+            "token": "1998-11-17:4515.00:4515.00:BC:Grocery - GB, Tervuren:true"
+        },
+        {
+            "accid": 1,
+            "comment": "Transfer FROM Kreditbank Savings",
+            "date": "1998-11-19",
+            "amount": "-50000.00",
             "type": "PNOW",
-            "locked": true
+            "id": 1343,
+            "locked": true,
+            "balance": "97583.00",
+            "token": "1998-11-19:::PNOW:Transfer FROM Kreditbank Savings:true"
         },
         {
             "accid": 1,
-            "comment": "Lindap blood work 14.12.2017 (019390313235) Labo Luc Olivier,Rue Leopold Genicot 16,5380,Fernelmont (BE50 3400 2450 0218) ",
-            "date": "2018-02-21",
-            "amount": "8.70",
-            "type": "PNOW"
+            "comment": "Transfer TO CERA Savings",
+            "date": "1998-11-19",
+            "amount": "50000.00",
+            "type": "PNOW",
+            "id": 1345,
+            "locked": true,
+            "balance": "47583.00",
+            "token": "1998-11-19:50000.00:50000.00:PNOW:Transfer TO CERA Savings:true"
         },
         {
             "accid": 1,
-            "comment": "Transfer FROM CBC-Esavings (EUR)",
-            "date": "2018-02-22",
-            "amount": "-1500.00",
-            "type": "TFR"
-        },
-        {
-            "accid": 1,
-            "comment": "TAX 2017 Income 2016 (077/8572/56427) (BE20 6792 0026 2156)",
-            "date": "2018-02-22",
-            "amount": "1132.45",
-            "type": "TAX"
-        },
-        {
-            "accid": 1,
-            "comment": "Transfer FROM CBC-Esavings (EUR)",
-            "date": "2018-02-22",
-            "amount": "-500.00",
-            "type": "TFR"
-        },
-        {
-            "accid": 1,
-            "comment": "Lindap Lambert Negoce bathroom cupboard",
-            "date": "2018-02-26",
-            "amount": "788.92",
-            "type": "TFR"
-        },
-        {
-            "accid": 1,
-            "comment": "Adele resto",
-            "date": "2018-02-20",
-            "amount": "2.72",
-            "type": "BC"
-        },
-        {
-            "accid": 1,
-            "comment": "Linda-Grocery  week 9 On:25 Feb 18",
-            "date": "2018-02-26",
-            "amount": "150.00",
-            "type": "GROC"
-        },
-        {
-            "accid": 1,
-            "comment": "Pay Feb 2018 On:25 Feb 18",
-            "date": "2018-02-28",
-            "amount": "-3553.40",
-            "type": "PAY"
-        },
-        {
-            "accid": 1,
-            "comment": "To Savings Mar 18 On:01 Mar 18",
-            "date": "2018-03-01",
-            "amount": "900.00",
-            "type": "SAVE"
-        },
-        {
-            "accid": 1,
-            "comment": "Pricos CPA Mar 2018 On:01 Mar 18",
-            "date": "2018-03-03",
-            "amount": "78.34",
-            "type": "PRIC"
-        },
-        {
-            "accid": 1,
-            "comment": "Hansard Mar 18 On:01 Mar 18",
-            "date": "2018-03-05",
-            "amount": "185.92",
-            "type": "PENS"
-        },
-        {
-            "accid": 1,
-            "comment": "TO PAY Proximus 2018 03 Ref X BE31 4354 1116 11 On:01 Mar 18",
-            "date": "2018-03-06",
-            "amount": "3.00",
-            "type": "ZOOM"
-        },
-        {
-            "accid": 1,
-            "comment": "TO PAY Scarlet 2018 03 Ref X On:01 Mar 18",
-            "date": "2018-03-07",
-            "amount": "49.95",
-            "type": "FEE"
-        },
-        {
-            "accid": 1,
-            "comment": "Luminus 2018 03 Ref 651164623857 - 335-0554598-95 Zoomit On:01 Mar 18",
-            "date": "2018-03-16",
-            "amount": "45.00",
-            "type": "ZOOM"
-        },
-        {
-            "accid": 1,
-            "comment": "Adele resto",
-            "date": "2018-02-27",
-            "amount": "3.03",
-            "type": "BC"
-        },
-        {
-            "accid": 1,
-            "comment": "Ph.Mouton Knee warmer,lens fluid",
-            "date": "2018-03-02",
-            "amount": "43.36",
-            "type": "BC"
-        },
-        {
-            "accid": 1,
-            "comment": "Lindap Vets Ghys Trim.Check",
-            "date": "2018-03-03",
-            "amount": "72.70",
-            "type": "ITFR"
-        },
-        {
-            "accid": 1,
-            "comment": "Vets Ghys LANCELOT 20-02-2017",
-            "date": "2018-03-03",
-            "amount": "249.99",
-            "type": "INET"
+            "comment": "Account closed",
+            "date": "1998-11-19",
+            "amount": "47583.00",
+            "type": "PNOW",
+            "id": 1347,
+            "locked": true,
+            "balance": "0.00",
+            "token": "1998-11-19:47583.00:47583.00:PNOW:Account closed:true"
         }
     ]
 }

--- a/account.ui/src/assets/accountapi/listtransaction/22
+++ b/account.ui/src/assets/accountapi/listtransaction/22
@@ -1,0 +1,279 @@
+{
+    "transactions": [
+        {
+            "accid": 22,
+            "comment": "Pricos CPA Aug 2024 On:28 Sept 24",
+            "date": "2024-08-03",
+            "amount": "78.34",
+            "type": "PRIC",
+            "id": 13752,
+            "locked": false,
+            "balance": "83715.11",
+            "token": "2024-08-03:78.34:78.34:PRIC:Pricos CPA Aug 2024 On:28 Sept 24:false"
+        },
+        {
+            "accid": 22,
+            "comment": "Hansard Aug 24 On:28 Sept 24",
+            "date": "2024-08-05",
+            "amount": "185.92",
+            "type": "PENS",
+            "id": 13754,
+            "locked": false,
+            "balance": "83529.19",
+            "token": "2024-08-05:185.92:185.92:PENS:Hansard Aug 24 On:28 Sept 24:false"
+        },
+        {
+            "accid": 22,
+            "comment": "Linda-Grocery  week 32 On:28 Sept 24",
+            "date": "2024-08-05",
+            "amount": "150.00",
+            "type": "GROC",
+            "id": 13756,
+            "locked": false,
+            "balance": "83379.19",
+            "token": "2024-08-05:150.00:150.00:GROC:Linda-Grocery  week 32 On:28 Sept 24:false"
+        },
+        {
+            "accid": 22,
+            "comment": "TO PAY Proximus 2024 08 Ref X BE31 4354 1116 11 On:28 Sept 24",
+            "date": "2024-08-06",
+            "amount": "3.00",
+            "type": "ZOOM",
+            "id": 13758,
+            "locked": false,
+            "balance": "83376.19",
+            "token": "2024-08-06:3.00:3.00:ZOOM:TO PAY Proximus 2024 08 Ref X BE31 4354 1116 11 On:28 Sept 24:false"
+        },
+        {
+            "accid": 22,
+            "comment": "TO PAY Scarlet 2024 08 Ref X On:28 Sept 24",
+            "date": "2024-08-07",
+            "amount": "49.95",
+            "type": "FEE",
+            "id": 13759,
+            "locked": false,
+            "balance": "83326.24",
+            "token": "2024-08-07:49.95:49.95:FEE:TO PAY Scarlet 2024 08 Ref X On:28 Sept 24:false"
+        },
+        {
+            "accid": 22,
+            "comment": "Linda-Grocery  week 33 On:28 Sept 24",
+            "date": "2024-08-12",
+            "amount": "150.00",
+            "type": "GROC",
+            "id": 13761,
+            "locked": false,
+            "balance": "83176.24",
+            "token": "2024-08-12:150.00:150.00:GROC:Linda-Grocery  week 33 On:28 Sept 24:false"
+        },
+        {
+            "accid": 22,
+            "comment": "TO PAY Luminus 2024 08 Ref X - 335-0554598-95 Zoomit On:28 Sept 24",
+            "date": "2024-08-18",
+            "amount": "45.00",
+            "type": "ZOOM",
+            "id": 13763,
+            "locked": false,
+            "balance": "83131.24",
+            "token": "2024-08-18:45.00:45.00:ZOOM:TO PAY Luminus 2024 08 Ref X - 335-0554598-95 Zoomit On:28 Sept 24:false"
+        },
+        {
+            "accid": 22,
+            "comment": "Linda-Grocery  week 34 On:28 Sept 24",
+            "date": "2024-08-19",
+            "amount": "150.00",
+            "type": "GROC",
+            "id": 13764,
+            "locked": false,
+            "balance": "82981.24",
+            "token": "2024-08-19:150.00:150.00:GROC:Linda-Grocery  week 34 On:28 Sept 24:false"
+        },
+        {
+            "accid": 22,
+            "comment": "TO PAY SWDE 2024 08 Ref X 444-4769-09161 On:28 Sept 24",
+            "date": "2024-08-26",
+            "amount": "89.72",
+            "type": "ZOOM",
+            "id": 13766,
+            "locked": false,
+            "balance": "82891.52",
+            "token": "2024-08-26:89.72:89.72:ZOOM:TO PAY SWDE 2024 08 Ref X 444-4769-09161 On:28 Sept 24:false"
+        },
+        {
+            "accid": 22,
+            "comment": "Linda-Grocery  week 35 On:28 Sept 24",
+            "date": "2024-08-26",
+            "amount": "150.00",
+            "type": "GROC",
+            "id": 13767,
+            "locked": false,
+            "balance": "82741.52",
+            "token": "2024-08-26:150.00:150.00:GROC:Linda-Grocery  week 35 On:28 Sept 24:false"
+        },
+        {
+            "accid": 22,
+            "comment": "Monthly Bank Charge Aug 2024 On:28 Sept 24",
+            "date": "2024-08-28",
+            "amount": "2.40",
+            "type": "BANK",
+            "id": 13769,
+            "locked": false,
+            "balance": "82739.12",
+            "token": "2024-08-28:2.40:2.40:BANK:Monthly Bank Charge Aug 2024 On:28 Sept 24:false"
+        },
+        {
+            "accid": 22,
+            "comment": "Pay Aug 2024 On:28 Sept 24",
+            "date": "2024-08-28",
+            "amount": "-3000.00",
+            "type": "PAY",
+            "id": 13770,
+            "locked": false,
+            "balance": "85739.12",
+            "token": "2024-08-28:::PAY:Pay Aug 2024 On:28 Sept 24:false"
+        },
+        {
+            "accid": 22,
+            "comment": "To Savings Sept 24 On:28 Sept 24",
+            "date": "2024-09-01",
+            "amount": "900.00",
+            "type": "SAVE",
+            "id": 13771,
+            "locked": false,
+            "balance": "84839.12",
+            "token": "2024-09-01:900.00:900.00:SAVE:To Savings Sept 24 On:28 Sept 24:false"
+        },
+        {
+            "accid": 22,
+            "comment": "Linda-Grocery  week 36 On:28 Sept 24",
+            "date": "2024-09-02",
+            "amount": "150.00",
+            "type": "GROC",
+            "id": 13773,
+            "locked": false,
+            "balance": "84689.12",
+            "token": "2024-09-02:150.00:150.00:GROC:Linda-Grocery  week 36 On:28 Sept 24:false"
+        },
+        {
+            "accid": 22,
+            "comment": "Pricos CPA Sept 2024 On:28 Sept 24",
+            "date": "2024-09-03",
+            "amount": "78.34",
+            "type": "PRIC",
+            "id": 13775,
+            "locked": false,
+            "balance": "84610.78",
+            "token": "2024-09-03:78.34:78.34:PRIC:Pricos CPA Sept 2024 On:28 Sept 24:false"
+        },
+        {
+            "accid": 22,
+            "comment": "Hansard Sept 24 On:28 Sept 24",
+            "date": "2024-09-05",
+            "amount": "185.92",
+            "type": "PENS",
+            "id": 13777,
+            "locked": false,
+            "balance": "84424.86",
+            "token": "2024-09-05:185.92:185.92:PENS:Hansard Sept 24 On:28 Sept 24:false"
+        },
+        {
+            "accid": 22,
+            "comment": "TO PAY Proximus 2024 09 Ref X BE31 4354 1116 11 On:28 Sept 24",
+            "date": "2024-09-06",
+            "amount": "3.00",
+            "type": "ZOOM",
+            "id": 13779,
+            "locked": false,
+            "balance": "84421.86",
+            "token": "2024-09-06:3.00:3.00:ZOOM:TO PAY Proximus 2024 09 Ref X BE31 4354 1116 11 On:28 Sept 24:false"
+        },
+        {
+            "accid": 22,
+            "comment": "TO PAY Scarlet 2024 09 Ref X On:28 Sept 24",
+            "date": "2024-09-07",
+            "amount": "49.95",
+            "type": "FEE",
+            "id": 13780,
+            "locked": false,
+            "balance": "84371.91",
+            "token": "2024-09-07:49.95:49.95:FEE:TO PAY Scarlet 2024 09 Ref X On:28 Sept 24:false"
+        },
+        {
+            "accid": 22,
+            "comment": "Linda-Grocery  week 37 On:28 Sept 24",
+            "date": "2024-09-09",
+            "amount": "150.00",
+            "type": "GROC",
+            "id": 13781,
+            "locked": false,
+            "balance": "84221.91",
+            "token": "2024-09-09:150.00:150.00:GROC:Linda-Grocery  week 37 On:28 Sept 24:false"
+        },
+        {
+            "accid": 22,
+            "comment": "Linda-Grocery  week 38 On:28 Sept 24",
+            "date": "2024-09-16",
+            "amount": "150.00",
+            "type": "GROC",
+            "id": 13784,
+            "locked": false,
+            "balance": "84071.91",
+            "token": "2024-09-16:150.00:150.00:GROC:Linda-Grocery  week 38 On:28 Sept 24:false"
+        },
+        {
+            "accid": 22,
+            "comment": "TO PAY Luminus 2024 09 Ref X - 335-0554598-95 Zoomit On:28 Sept 24",
+            "date": "2024-09-18",
+            "amount": "45.00",
+            "type": "ZOOM",
+            "id": 13786,
+            "locked": false,
+            "balance": "84026.91",
+            "token": "2024-09-18:45.00:45.00:ZOOM:TO PAY Luminus 2024 09 Ref X - 335-0554598-95 Zoomit On:28 Sept 24:false"
+        },
+        {
+            "accid": 22,
+            "comment": "Linda-Grocery  week 39 On:28 Sept 24",
+            "date": "2024-09-23",
+            "amount": "150.00",
+            "type": "GROC",
+            "id": 13787,
+            "locked": false,
+            "balance": "83876.91",
+            "token": "2024-09-23:150.00:150.00:GROC:Linda-Grocery  week 39 On:28 Sept 24:false"
+        },
+        {
+            "accid": 22,
+            "comment": "Monthly Bank Charge Sept 2024 On:28 Sept 24",
+            "date": "2024-09-28",
+            "amount": "2.40",
+            "type": "BANK",
+            "id": 13789,
+            "locked": false,
+            "balance": "83874.51",
+            "token": "2024-09-28:2.40:2.40:BANK:Monthly Bank Charge Sept 2024 On:28 Sept 24:false"
+        },
+        {
+            "accid": 22,
+            "comment": "Pay Sept 2024 On:28 Sept 24",
+            "date": "2024-09-28",
+            "amount": "-3000.00",
+            "type": "PAY",
+            "id": 13790,
+            "locked": false,
+            "balance": "86874.51",
+            "token": "2024-09-28:::PAY:Pay Sept 2024 On:28 Sept 24:false"
+        },
+        {
+            "accid": 22,
+            "comment": "To Savings Oct 24 On:28 Sep 24",
+            "date": "2024-10-01",
+            "amount": "900.00",
+            "type": "SAVE",
+            "id": 13792,
+            "locked": false,
+            "balance": "85974.51",
+            "token": "2024-10-01:900.00:900.00:SAVE:To Savings Oct 24 On:28 Sep 24:false"
+        }
+    ]
+}

--- a/account.ui/src/environments/environment.nobe.ts
+++ b/account.ui/src/environments/environment.nobe.ts
@@ -5,6 +5,6 @@ export const environment = {
   accountapi_host: "http://localhost:4200",
   accountapi_app: "/accountapi/",
   envName: ' (NODB)',
-  uiversion: ' ng18l',
+  uiversion: ' dbal',
   folder: '/assets'  
 };

--- a/account.ui/src/environments/environment.prod.ts
+++ b/account.ui/src/environments/environment.prod.ts
@@ -5,6 +5,6 @@ export const environment = {
   accountapi_host: "", // http://minnie",
   accountapi_app: "/jaccountapi/",
   envName: ' (J-LIVE)',  
-  uiversion: ' ui4.3',
+  uiversion: ' ui4.4a',
   folder: ''
 };

--- a/account.ui/src/sass/account-styles.scss
+++ b/account.ui/src/sass/account-styles.scss
@@ -21,4 +21,6 @@
    @extend .my-0;
    @extend .py-0;
    --bs-btn-line-height: 16px;
+   --bs-btn-border-width: 0;
+   border-bottom-width: 0;
 }

--- a/account.ui/src/sass/account-styles.scss
+++ b/account.ui/src/sass/account-styles.scss
@@ -13,3 +13,12 @@
    @extend .input-group-sm;
    @extend .mb-2;
 }
+
+
+.acc-table-btn
+{
+   @extend .btn;
+   @extend .my-0;
+   @extend .py-0;
+   --bs-btn-line-height: 16px;
+}

--- a/account.ui/src/shared/model/transaction.model.ts
+++ b/account.ui/src/shared/model/transaction.model.ts
@@ -8,6 +8,7 @@ export class TransactionItem
     public id: string = '';
     public locked: boolean = false;
     public token: string = '';
+    public balance : string = '';
     
     constructor()
     {
@@ -20,9 +21,11 @@ export class TransactionItem
       this.comment = item.comment;
       this.date = item.date;
       this.amount = item.amount;
+      this.balance = item.balance;
       this.type = item.type;
       this.id = item.id;
       this.locked = item.locked;
       this.token = item.token;
+
     }
 }


### PR DESCRIPTION
Balance is now calculated for add and update transaction when modified via the UI.
UI finally has a more sensible display - greatly reduced the excessive whitespace in the transaction list - which will hopefully provide the base for the other lists.
Display on desktop browsers includes the balance (still missing the type, locked and statement reference columns)