### PR TITLE
standing order end of month processing

### DIFF
--- a/account.api/src/main/java/com/felixalacampagne/account/standingorder/StandingOrderUtils.java
+++ b/account.api/src/main/java/com/felixalacampagne/account/standingorder/StandingOrderUtils.java
@@ -1,0 +1,96 @@
+package com.felixalacampagne.account.standingorder;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalUnit;
+
+public class StandingOrderUtils
+{
+   public String expandSOmemo(String memo, LocalDate txndate, LocalDate entdate)
+   {
+      int i;
+      int e;
+      String srtn = memo;
+      String sl;
+      String sr;
+      String pat;
+      LocalDate fmtdate;
+
+      do
+      {
+         i = srtn.indexOf('#');
+         if(i < 0)
+         {
+            break;
+         }
+         e = srtn.indexOf('#', i+1);
+         if(e < 0)
+         {
+            break;
+         }
+
+         sl = "";
+         sr = "";
+
+         if(i > 0)
+            sl = srtn.substring(0, i);
+
+         if(e < srtn.length())
+            sr = srtn.substring(e+1, srtn.length());
+
+         pat = srtn.substring(i+1, e);
+
+         fmtdate = txndate;
+         if(pat.startsWith("E"))
+         {
+            pat = pat.substring(1, pat.length());
+            if(entdate != null)
+            {
+               fmtdate = entdate;
+            }
+         }
+         // pat should now be a VB date format - unfortunately this is not the same as a Java date format
+         // There are only a few formats actually used and the main difference is for month, ie. m vs. M for java
+         pat = pat.replace('m', 'M');
+         DateTimeFormatter df = DateTimeFormatter.ofPattern(pat);
+
+         srtn = sl + df.format(fmtdate) + sr;
+      }while(true);
+
+      return srtn;
+   }
+
+   public boolean isEndOfMonth(LocalDate d)
+   {
+      return (d.getDayOfMonth() == d.lengthOfMonth());
+   }
+   
+   public LocalDate adjustMonthWithEOM(LocalDate orig, long offset)
+   {
+      LocalDate next = orig.plusMonths(offset);
+      
+      if(isEndOfMonth(orig))
+      {
+         // nextEOM = nextEOM.withDayOfMonth(nextEOM.lengthOfMonth());
+         next = YearMonth.from(next).atEndOfMonth();
+      }
+      return next;
+   }
+   
+
+   public LocalDate adjustDate(LocalDate origdate, TemporalUnit periodUnit, long numperiods)
+   {
+      LocalDate adjustdate = origdate;
+      if(ChronoUnit.MONTHS.equals(periodUnit))
+      {
+         adjustdate = adjustMonthWithEOM(origdate, numperiods);
+      }
+      else
+      {
+         adjustdate = adjustdate.plus(numperiods, periodUnit);
+      }
+      return adjustdate; //Date.valueOf(adjustdate);
+   }   
+}

--- a/account.api/src/main/resources/application.properties
+++ b/account.api/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 falc.account.name=JAccount
 falc.account.db=LIVE
-falc.account.version=0.4.24.1
+falc.account.version=0.4.25a
 #   second
 #   minute
 #   hour

--- a/account.api/src/test/java/com/felixalacampagne/account/standingorder/StandingOrderProcessorTest.java
+++ b/account.api/src/test/java/com/felixalacampagne/account/standingorder/StandingOrderProcessorTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -80,5 +81,18 @@ public class StandingOrderProcessorTest
 
        nextexec = cron.next(nextexec.plusMinutes(2));
        log.info("testCron: next execution time after: {}", nextexec);
+   }
+   
+   @Test
+   void lastDayOfMonth()
+   {
+      LocalDate origEOM = LocalDate.of(2025, 06, 30);
+      LocalDate nextEOM;
+      String memotmpl;
+      String memo;
+      nextEOM = origEOM.plus(1, ChronoUnit.MONTHS);
+      memotmpl = "next #dd mm yyyy#, orig #Edd mm yyyy";
+      memo = standingOrderProcessor.expandSOmemo(memotmpl, nextEOM, origEOM);
+      log.info("lastDayOfMonth: {}", memo);
    }
 }

--- a/account.api/src/test/java/com/felixalacampagne/account/standingorder/StandingOrderUtilsTest.java
+++ b/account.api/src/test/java/com/felixalacampagne/account/standingorder/StandingOrderUtilsTest.java
@@ -1,0 +1,51 @@
+package com.felixalacampagne.account.standingorder;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.temporal.ChronoUnit;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class StandingOrderUtilsTest
+{
+   Logger log = LoggerFactory.getLogger(this.getClass());
+   StandingOrderUtils soUtils = new StandingOrderUtils();
+   
+   @Test
+   void lastDayOfMonth()
+   {
+      LocalDate origEOM;
+      LocalDate nextEOM;
+      String memotmpl;
+      String memo;
+      
+      memotmpl = "#dd mm yyyy#";
+
+      // 31/05 -> 30/06
+      origEOM = LocalDate.of(2025, 05, 31);
+      nextEOM = origEOM.plus(1, ChronoUnit.MONTHS);
+      memo = soUtils.expandSOmemo(memotmpl, nextEOM, nextEOM);
+      log.info("lastDayOfMonth: orig:{} next:{}", soUtils.expandSOmemo(memotmpl, origEOM, origEOM), memo);
+      assertEquals("30 06 2025", memo);
+      
+      // 30/06 -> 30/07 (lastDOM=31/07) can't use 32/06 or 31/06 - must be valid DOM value
+      origEOM = LocalDate.of(2025, 02, 28);
+      nextEOM = soUtils.adjustMonthWithEOM(origEOM, 1);
+
+      memo = soUtils.expandSOmemo(memotmpl, nextEOM, nextEOM);
+      log.info("lastDayOfMonth: orig:{} next:{}", soUtils.expandSOmemo(memotmpl, origEOM, origEOM), memo);
+      assertEquals("31 03 2025", memo);
+   
+      origEOM = LocalDate.of(2025, 01, 31);
+      nextEOM = soUtils.adjustMonthWithEOM(origEOM, 3);
+
+      memo = soUtils.expandSOmemo(memotmpl, nextEOM, nextEOM);
+      log.info("lastDayOfMonth: orig:{} next:{}", soUtils.expandSOmemo(memotmpl, origEOM, origEOM), memo);
+      assertEquals("30 04 2025", memo);
+
+   }
+}


### PR DESCRIPTION
adjusts new entry and pay dates to be the end of the month if the current values are at the end of the month. 
This means that dates on or after 28th will eventually become the end of the month - if this must be avoided then either a DB update is required (which is really to be avoided) or 'meta' data will need to be added to one of the fields, probably the description.